### PR TITLE
feat: add GitLab CI merge request client

### DIFF
--- a/claudecode/__init__.py
+++ b/claudecode/__init__.py
@@ -12,11 +12,13 @@ __author__ = "Anthropic Security Team"
 from claudecode.github_action_audit import (
     GitHubActionClient,
     SimpleClaudeRunner,
-    main
+    main,
 )
+from claudecode.gitlab_ci_client import GitLabCIClient
 
 __all__ = [
     "GitHubActionClient",
+    "GitLabCIClient",
     "SimpleClaudeRunner",
-    "main"
+    "main",
 ]


### PR DESCRIPTION
## Summary
- add `GitLabCIClient` to fetch merge request data and diffs
- expose GitLab client in package init

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dcb59ab00832eba896fac29c593d1